### PR TITLE
Always pass node object to grid.editor route

### DIFF
--- a/grid.routing.yml
+++ b/grid.routing.yml
@@ -14,6 +14,9 @@ grid.editor:
     _grid_access: "{node}"
   options:
     _admin_route: true
+    parameters:
+      node:
+        type: entity:node
 
 grid.editor.ajax:
   path: '/grid_ajax_endpoint'

--- a/src/Controller/GridEditorController.php
+++ b/src/Controller/GridEditorController.php
@@ -27,7 +27,8 @@ class GridEditorController extends ControllerBase implements AccessInterface
 {
     public function editor(RouteMatchInterface $match)
     {
-        $nid=$match->getParameter("node");
+        $node_param=$match->getParameter("node");
+        $nid = is_object($node_param) ? $node_param->id() : $node_param;
         $grid_id=grid_get_grid_by_nid($nid);
         if($grid_id===FALSE)
         {
@@ -167,13 +168,13 @@ class GridEditorController extends ControllerBase implements AccessInterface
         {
 	        return AccessResult::allowedIfHasPermission($account,"administer grid");
         }
-        $nid=$match->getParameter("node");
-        /** @var NodeInterface $node */
-        $node=Node::load($nid);
-	if(method_exists($node, "getType")){
-        	$type=$node->getType();
-        }else{
-	        return AccessResult::forbidden();
+        $node_param = $match->getParameter("node");
+        $node = is_object($node_param) ? $node_param : Node::load($node_param);
+
+        if ($node && method_exists($node, "getType")) {
+            $type = $node->getType();
+        } else {
+            return AccessResult::forbidden();
         }
 
         $enabled=$this->config("grid.settings")->get("enabled_node_types");


### PR DESCRIPTION
This prevents problems with at least one backend theme (Gin).